### PR TITLE
Nil in ack-create-master

### DIFF
--- a/full-ack.el
+++ b/full-ack.el
@@ -583,7 +583,7 @@ DIRECTORY is the root directory.  If called interactively, it is determined by
   (let ((file (ack-previous-property-value 'ack-file pos))
         (line (ack-previous-property-value 'ack-line pos))
         (offset (ack-visible-distance
-                 (previous-single-property-change pos 'ack-line) pos))
+                 (or (previous-single-property-change pos 'ack-line) 0) pos))
         buffer)
     (if force
         (or (and file


### PR DESCRIPTION
Fixes #2 by defaulting the beg of the offset in ack-create-master to 0 when the call to previous-single-property-change returns nil

Turns out, this problem is common enough that googling "previous-single-property-change" has http://www.mail-archive.com/emacs-orgmode@gnu.org/msg09357.html as its second hit. Went through org-mode's revision history around that time and found the fix in f84ce1cecff89178abde4c1c98914af0eab7aa67. Whew.
