### PR TITLE
Allow single character color codes

### DIFF
--- a/full-ack.el
+++ b/full-ack.el
@@ -689,7 +689,7 @@ DIRECTORY is the root directory.  If called interactively, it is determined by
     (define-key keymap "r" 'ack-again)
     keymap))
 
-(defconst ack-font-lock-regexp-color-fg-begin "\\(\33\\[1;..m\\)")
+(defconst ack-font-lock-regexp-color-fg-begin "\\(\33\\[1;..?m\\)")
 (defconst ack-font-lock-regexp-color-bg-begin "\\(\33\\[30;..m\\)")
 (defconst ack-font-lock-regexp-color-end "\\(\33\\[0m\\)")
 


### PR DESCRIPTION
For some reason my ack output only has 1 character in the color code. e.g.:

[1;2msrc/test/cucumber/features/my.feature[0m

This causes ack-font-lock-regexp-color-fg-begin not to match, so I've modified it to accept either one or two characters. Sending a pull request in case this might affect other users.
