### PR TITLE
Auto close results

### DIFF
--- a/full-ack.el
+++ b/full-ack.el
@@ -333,7 +333,7 @@ This can be used in `ack-root-directory-functions'."
         (if (> c 0)
             (when (eq ack-display-buffer 'after)
               (display-buffer (current-buffer)))
-          (kill-buffer (current-buffer)))
+          (kill-buffer-and-window))
         (message "Ack finished with %d match%s" c (if (eq c 1) "" "es"))))))
 
 (defun ack-filter (proc output)

--- a/full-ack.el
+++ b/full-ack.el
@@ -699,7 +699,8 @@ DIRECTORY is the root directory.  If called interactively, it is determined by
                   (marker-buffer marker))
       (compilation-goto-locus msg marker end)
       (set-marker msg nil)
-      (set-marker end nil))))
+      (set-marker end nil)
+      (delete-other-windows))))
 
 ;;; ack-mode ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
I've modified full ack to:
- automatically close the results window when there are no results
- close the results window after browsing to a result using `ack-find-match`

I find it a little annoying to have an empty results window left open when the minibuffer will tell me there were 0 results. Also I seldom want to look at alternative results after browsing to the one I want.

I don't know if either of these are generally desired behaviour. I know that some emacs users prefer to have a fixed window split where all temporary results oriented buffers are displayed and I'm not sure how this would interact with that.

Thoughts?
