### PR TITLE
thing-at-point ought to be regex quoted ...

### DIFF
--- a/full-ack.el
+++ b/full-ack.el
@@ -449,7 +449,7 @@ This can be used in `ack-root-directory-functions'."
 
 (defun ack--default-for-read ()
   (unless (ack--use-region-p)
-    (thing-at-point 'symbol)))
+    (regexp-quote (thing-at-point 'symbol))))
 
 (defun ack--use-region-p ()
   (or (and (fboundp 'use-region-p) (use-region-p))


### PR DESCRIPTION
I suspect it's unlikely that when defaulting is snarfing text from a buffer that text is already a regex.  So I wrapped the call to thing-at-point to quotify any regex chars.
